### PR TITLE
add collect_asset_docs method to Xspress3FileStore

### DIFF
--- a/ssrltools/devices/xspress3.py
+++ b/ssrltools/devices/xspress3.py
@@ -208,6 +208,12 @@ class Xspress3FileStore(FileStorePluginBase, HDF5Plugin):
 
         return desc
 
+    def collect_asset_docs(self):
+        items = list(self._asset_docs_cache)
+        self._asset_docs_cache.clear()
+        for item in items:
+            yield item
+
     def warmup(self):
         """
         A convenience method for 'priming' the plugin.  
@@ -242,8 +248,6 @@ class Xspress3FileStore(FileStorePluginBase, HDF5Plugin):
             set_and_wait(sig, val)
 
         print("done")
-
-
 
 class Xspress3DetectorSettings(CamBase):
     '''Quantum Detectors Xspress3 detector'''


### PR DESCRIPTION
Adds the required collect_asset_docs functionality to the filestore class.  

will require fixes to the top-level detector object that finds and calls this method